### PR TITLE
Improve error handling for market data fetch

### DIFF
--- a/api/app/services/market.py
+++ b/api/app/services/market.py
@@ -1,5 +1,7 @@
-import re, requests, yfinance as yf
+import logging, re, requests, yfinance as yf
 from datetime import datetime
+
+logger = logging.getLogger(__name__)
 
 symbol_regex = re.compile(r'^([A-Za-z]+)(\d{6})([CP])(\d+)$')
 
@@ -21,5 +23,38 @@ def parse(symbol: str):
 
 def last_prices(roots: list[str]) -> dict[str, float]:
     url = "https://query1.finance.yahoo.com/v7/finance/quote"
-    data = requests.get(url, params={"symbols": ",".join(roots)}).json()
-    return {d["symbol"]: d["regularMarketPrice"] for d in data["quoteResponse"]["result"]}
+    response = requests.get(url, params={"symbols": ",".join(roots)})
+    response.raise_for_status()
+    try:
+        data = response.json()
+    except ValueError as exc:
+        snippet = response.text[:200]
+        logger.error(
+            "Failed to decode JSON from %s: status %s, body %r",
+            url,
+            response.status_code,
+            snippet,
+        )
+        raise ValueError(
+            f"Failed to decode JSON from {url}: status {response.status_code}, body: {snippet}"
+        ) from exc
+
+    result = data.get("quoteResponse", {}).get("result", [])
+    if not result:
+        logger.warning(
+            "No price data returned from %s for symbols %s; falling back to yfinance",
+            url,
+            roots,
+        )
+        price_map: dict[str, float] = {}
+        for root in roots:
+            try:
+                price = yf.Ticker(root).info.get("regularMarketPrice")
+            except Exception as exc:  # pragma: no cover - network errors
+                logger.error("yfinance failed for %s: %s", root, exc)
+                continue
+            if price is not None:
+                price_map[root] = price
+        return price_map
+
+    return {d["symbol"]: d["regularMarketPrice"] for d in result}


### PR DESCRIPTION
## Summary
- log and raise errors when fetching last prices fails to decode JSON
- fall back to yfinance when Yahoo quote API returns no data

## Testing
- `pytest` *(fails: ImportError: cannot import name 'produce_quote' from 'producer')*

------
https://chatgpt.com/codex/tasks/task_e_68911c959b748329ace22237f2506c91